### PR TITLE
Type complexity algorithm

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,5 +26,5 @@
             "error"
         ]
     }, 
-    "ignorePatterns": ["jest.*"]
+    "ignorePatterns": ["jest.*", "build/*"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+build/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [{
+        "type": "node",
+        "request": "launch",
+        "name": "Jest Tests",
+        "program": "${workspaceRoot}\\node_modules\\jest\\bin\\jest.js",
+        "args": [
+            "-i"
+        ],
+        // "preLaunchTask": "build",
+        "internalConsoleOptions": "openOnSessionStart",
+        "outFiles": [
+            "${workspaceRoot}/dist/**/*"
+        ],
+        "envFile": "${workspaceRoot}/.env"
+      }]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,15 +7,15 @@
         "type": "node",
         "request": "launch",
         "name": "Jest Tests",
-        "program": "${workspaceRoot}\\node_modules\\jest\\bin\\jest.js",
+        "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
         "args": [
-            "-i"
+            "-i", "--verbose", "--no-cache"
         ],
         // "preLaunchTask": "build",
-        "internalConsoleOptions": "openOnSessionStart",
-        "outFiles": [
-            "${workspaceRoot}/dist/**/*"
-        ],
-        "envFile": "${workspaceRoot}/.env"
+        // "internalConsoleOptions": "openOnSessionStart",
+        // "outFiles": [
+        //     "${workspaceRoot}/dist/**/*"
+        // ],
+        // "envFile": "${workspaceRoot}/.env"
       }]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,19 @@
     "source.fixAll.eslint": true
   },
   "editor.formatOnSave": true,
+  "configurations": [{
+    "type": "node",
+    "request": "launch",
+    "name": "Jest Tests",
+    "program": "${workspaceRoot}\\node_modules\\jest\\bin\\jest.js",
+    "args": [
+        "-i"
+    ],
+    // "preLaunchTask": "build",
+    "internalConsoleOptions": "openOnSessionStart",
+    "outFiles": [
+        "${workspaceRoot}/dist/**/*"
+    ],
+    "envFile": "${workspaceRoot}/.env"
+  }]
 }

--- a/src/@types/buildTypeWeights.d.ts
+++ b/src/@types/buildTypeWeights.d.ts
@@ -1,19 +1,16 @@
-interface Fields {
+export interface Fields {
     [index: string]: FieldWeight;
 }
-type WeightFunction = (args: ArgumentNode[]) => number;
-type FieldWeight = number | WeightFunction;
-
-interface Type {
+export type WeightFunction = (args: ArgumentNode[]) => number;
+export type FieldWeight = number | WeightFunction;
+export interface Type {
     readonly weight: number;
     readonly fields: Fields;
 }
-
-interface TypeWeightObject {
+export interface TypeWeightObject {
     [index: string]: Type;
 }
-
-interface TypeWeightConfig {
+export interface TypeWeightConfig {
     mutation?: number;
     query?: number;
     object?: number;

--- a/src/@types/buildTypeWeights.d.ts
+++ b/src/@types/buildTypeWeights.d.ts
@@ -1,5 +1,5 @@
 interface Fields {
-    readonly [index: string]: number | ((arg: number, type: Type) => number);
+    readonly [index: string]: number | ((arg: { [index: string]: any }) => number);
 }
 
 interface Type {

--- a/src/@types/rateLimit.d.ts
+++ b/src/@types/rateLimit.d.ts
@@ -1,4 +1,4 @@
-interface RateLimiter {
+export interface RateLimiter {
     /**
      * Checks if a request is allowed under the given conditions and withdraws the specified number of tokens
      * @param uuid Unique identifier for the user associated with the request
@@ -13,17 +13,17 @@ interface RateLimiter {
     ) => Promise<RateLimiterResponse>;
 }
 
-interface RateLimiterResponse {
+export interface RateLimiterResponse {
     success: boolean;
     tokens: number;
 }
 
-interface RedisBucket {
+export interface RedisBucket {
     tokens: number;
     timestamp: number;
 }
 
-type RateLimiterSelection =
+export type RateLimiterSelection =
     | 'TOKEN_BUCKET'
     | 'LEAKY_BUCKET'
     | 'FIXED_WINDOW'
@@ -34,7 +34,7 @@ type RateLimiterSelection =
  * @type {number} bucketSize - Size of the token bucket
  * @type {number} refillRate - Rate at which tokens are added to the bucket in seconds
  */
-interface TokenBucketOptions {
+export interface TokenBucketOptions {
     bucketSize: number;
     refillRate: number;
 }
@@ -42,4 +42,4 @@ interface TokenBucketOptions {
 // TODO: This will be a union type where we can specify Option types for other Rate Limiters
 // Record<string, never> represents the empty object for alogorithms that don't require settings
 // and might be able to be removed in the future.
-type RateLimiterOptions = TokenBucketOptions | Record<string, never>;
+export type RateLimiterOptions = TokenBucketOptions | Record<string, never>;

--- a/src/analysis/ASTnodefunctions.ts
+++ b/src/analysis/ASTnodefunctions.ts
@@ -10,6 +10,7 @@ import {
 } from 'graphql';
 
 // TODO: handle variables and arguments
+// ! this is not functional
 const getArgObj = (args: ArgumentNode[]): { [index: string]: any } => {
     const argObj: { [index: string]: any } = {};
     for (let i = 0; i < args.length; i + 1) {
@@ -23,6 +24,25 @@ const getArgObj = (args: ArgumentNode[]): { [index: string]: any } => {
     }
     return argObj;
 };
+/**
+ * The AST node functions call each other following the nested structure below
+ * Each function handles a specific GraphQL AST node type
+ *
+ * AST nodes call each other in the following way
+ *
+ *                        Document Node
+ *                            |
+ *                        Definiton Node
+ *              (operation and fragment definitons)
+ *                     /                \
+ *  |-----> Selection Set Node         not done
+ *  |               /
+ *  |          Selection Node
+ *  |  (Field, Inline fragment and fragment spread)
+ *  |      |            \               \
+ *  |--Field Node       not done       not done
+ *
+ */
 
 export function fieldNode(
     node: FieldNode,
@@ -54,6 +74,7 @@ export function fieldNode(
         } else {
             // otherwise the the feild weight is a list, invoke the function with variables
             // TODO: calculate the complexity for lists with arguments and varibales
+            // ! this is not functional
             // iterate through the arguments to build the object to
             // eslint-disable-next-line no-lonely-if
             if (node.arguments) {

--- a/src/analysis/ASTnodefunctions.ts
+++ b/src/analysis/ASTnodefunctions.ts
@@ -7,7 +7,6 @@ import {
     Kind,
     SelectionNode,
     ArgumentNode,
-    BooleanValueNode,
 } from 'graphql';
 
 // TODO: handle variables and arguments
@@ -39,7 +38,7 @@ export function fieldNode(
         complexity += typeWeights[node.name.value].weight;
         // call the function to handle selection set node with selectionSet property if it is not undefined
         if (node.selectionSet) {
-            complexity *= selectionSetNode(
+            complexity += selectionSetNode(
                 node.selectionSet,
                 typeWeights,
                 variables,
@@ -90,9 +89,8 @@ export function selectionSetNode(
     parentName: string
 ): number {
     let complexity = 0;
-    console.log('selectionSetNode', node.selections.length, parentName);
     // iterate shrough the 'selections' array on the seletion set node
-    for (let i = 0; i < node.selections.length; i + 1) {
+    for (let i = 0; i < node.selections.length; i += 1) {
         // call the function to handle seletion nodes
         // pass the current parent through because selection sets act only as intermediaries
         complexity += selectionNode(node.selections[i], typeWeights, variables, parentName);
@@ -106,7 +104,6 @@ export function definitionNode(
     variables: any | undefined
 ): number {
     let complexity = 0;
-    console.log('definitionTode', node);
     // check the kind property against the set of definiton nodes that are possible
     if (node.kind === Kind.OPERATION_DEFINITION) {
         // check if the operation is in the type weights object.
@@ -134,7 +131,7 @@ export function documentNode(
 ): number {
     let complexity = 0;
     // iterate through 'definitions' array on the document node
-    for (let i = 0; i < node.definitions.length; i + 1) {
+    for (let i = 0; i < node.definitions.length; i += 1) {
         // call the function to handle the various types of definition nodes
         complexity += definitionNode(node.definitions[i], typeWeights, variables);
     }

--- a/src/analysis/ASTnodefunctions.ts
+++ b/src/analysis/ASTnodefunctions.ts
@@ -1,0 +1,85 @@
+import {
+    DocumentNode,
+    FieldNode,
+    SelectionSetNode,
+    DefinitionNode,
+    Kind,
+    SelectionNode,
+} from 'graphql';
+
+export function fieldNode(
+    node: FieldNode,
+    typeWeights: TypeWeightObject,
+    variables: any | undefined,
+    parent: FieldNode | DefinitionNode
+): number {
+    const complexity = 0;
+    return complexity;
+}
+
+export function selectionNode(
+    node: SelectionNode,
+    typeWeights: TypeWeightObject,
+    variables: any | undefined,
+    parent: DefinitionNode | FieldNode
+): number {
+    let complexity = 0;
+    // check the kind property against the set of selection nodes that are possible
+    if (node.kind === Kind.FIELD) {
+        // call the function that handle field nodes and multiply the result into complexity to accound for nested fields
+        complexity *= fieldNode(node, typeWeights, variables, parent);
+    }
+    // TODO: add checks for Kind.FRAGMENT_SPREAD and Kind.INLINE_FRAGMENT here
+    return complexity;
+}
+
+export function selectionSetNode(
+    node: SelectionSetNode,
+    typeWeights: TypeWeightObject,
+    variables: any | undefined,
+    parent: DefinitionNode | FieldNode
+): number {
+    let complexity = 0;
+    // iterate shrough the 'selections' array on the seletion set node
+    for (let i = 0; i < node.selections.length; i + 1) {
+        // call the function to handle seletion nodes
+        // pass the current parent through because selection sets act only as intermediaries
+        complexity += selectionNode(node.selections[i], typeWeights, variables, parent);
+    }
+    return complexity;
+}
+
+export function definitionNode(
+    node: DefinitionNode,
+    typeWeights: TypeWeightObject,
+    variables: any | undefined
+): number {
+    let complexity = 0;
+    // check the kind property against the set of definiton nodes that are possible
+    if (node.kind === Kind.OPERATION_DEFINITION) {
+        // check if the operation is in the type weights object.
+        if (node.operation.toLocaleLowerCase() in typeWeights) {
+            // if it is, it is an object type, add it's type weight to the total
+            complexity += typeWeights[node.operation].weight;
+            // call the function to handle selection set node with selectionSet property if it is not undefined
+            if (node.selectionSet)
+                complexity += selectionSetNode(node.selectionSet, typeWeights, variables, node);
+        }
+    }
+    // TODO: add checks for Kind.FRAGMENT_DEFINITION here (there are other type definition nodes that i think we can ignore. see ast.d.ts in 'graphql')
+    return complexity;
+}
+
+export function documentNode(
+    node: DocumentNode,
+    typeWeights: TypeWeightObject,
+    variables: any | undefined
+): number {
+    let complexity = 0;
+    // iterate through 'definitions' array on the document node
+    for (let i = 0; i < node.definitions.length; i + 1) {
+        // call the function to handle the various types of definition nodes
+        complexity += definitionNode(node.definitions[i], typeWeights, variables);
+    }
+    return complexity;
+}

--- a/src/analysis/ASTnodefunctions.ts
+++ b/src/analysis/ASTnodefunctions.ts
@@ -8,6 +8,7 @@ import {
     SelectionNode,
     ArgumentNode,
 } from 'graphql';
+import { FieldWeight, TypeWeightObject } from '../@types/buildTypeWeights';
 
 // TODO: handle variables and arguments
 // ! this is not functional

--- a/src/analysis/typeComplexityAnalysis.ts
+++ b/src/analysis/typeComplexityAnalysis.ts
@@ -1,4 +1,5 @@
-import { DocumentNode } from 'graphql';
+import { query } from 'express';
+import { ASTNode, DocumentNode, Kind } from 'graphql';
 
 /**
  * This function should
@@ -11,18 +12,85 @@ import { DocumentNode } from 'graphql';
  *
  * TO DO: extend the functionality to work for mutations and subscriptions
  *
- * @param {string} queryString
- * @param {TypeWeightObject} typeWeights
+ * @param {string} queryAST
  * @param {any | undefined} varibales
- * @param {string} complexityOption
+ * @param {TypeWeightObject} typeWeights
  */
 // TODO add queryVaribables parameter
 function getQueryTypeComplexity(
-    queryString: DocumentNode,
+    queryAST: DocumentNode,
     varibales: any | undefined,
     typeWeights: TypeWeightObject
 ): number {
-    throw Error('getQueryComplexity is not implemented.');
+    const recursive = (node: ASTNode, parent: ASTNode | null = null): number => {
+        /** 
+         * pseudo code of the process
+         * 
+        // if 'kind' property is 'Document'
+            // iterate through queryAST.definitions array
+            // call recursive with object
+
+        // if 'kind' property is 'operationDefinition'
+            // check 'operation' value against the type weights and add to total
+            // call recursive with selectionSet property if it is not undefined
+
+        // if 'kind' is 'selectionSet'
+            // iterate shrough the 'selections' array of fields
+            // if 'selectinSet' is not undefined, call recursive with the field
+
+        // if 'kind' property is 'feild'
+            // check the fields name.value against the type weights and total
+            // if there is a match, it is an objcet type with feilds, 
+                // call recursive with selectionSet property if it is not undefined
+            // if it is not a match, it is a scalar field, look in the parent.name.value to check type weights feilds
+        */
+
+        let complexity = 0;
+        const parentName: string = parent?.operation || parent?.name.value || null;
+
+        if (node.kind === Kind.DOCUMENT) {
+            // if 'kind' property is a 'Document'
+            // iterate through queryAST.definitions array
+            for (let i = 0; i < node.definitions.length; i + 1) {
+                // call recursive with the definition node
+                complexity += recursive(node.definitions[i], node);
+            }
+        } else if (node.kind === Kind.OPERATION_DEFINITION) {
+            // if 'kind' property is 'operationDefinition'
+            // TODO: case-sensitive
+            if (node.operation in typeWeights) {
+                // check 'operation' value against the type weights and add to total
+                complexity += typeWeights[node.operation].weight;
+                // call recursive with selectionSet property if it is not undefined
+                if (node.selectionSet) complexity += recursive(node.selectionSet, node);
+            }
+        } else if (node.kind === Kind.SELECTION_SET) {
+            // if 'kind' is 'selectionSet'
+            // iterate shrough the 'selections' array of fields
+            for (let i = 0; i < node.selections.length; i + 1) {
+                // call recursive with the field
+                complexity += recursive(node.selections[i], parent); // passing the current parent through because selection sets act only as intermediaries
+            }
+        } else if (node.kind === Kind.FIELD) {
+            // if 'kind' property is 'field'
+            // check the fields name.value against the type weights and total
+            // TODO: case-sensitive
+            if (node.name.value in typeWeights) {
+                // if there is a match, it is an objcet type with feilds,
+                complexity += typeWeights[node.name.value].weight;
+                // call recursive with selectionSet property if it is not undefined
+                if (node.selectionSet) complexity += recursive(node.selectionSet, node);
+                // node.name.value in typeWeights[parent.operation || parent.name.value].fields
+            } else if (parent?.opeartion) {
+                // if it is not a match, it is a scalar field, look in the parent.name.value to check type weights feilds
+                // TODO: if it is a list, need to look at the parent
+                complexity += typeWeights[parent.name.value].fields[node.name.value];
+            }
+        }
+
+        return complexity;
+    };
+    return recursive(queryAST);
 }
 
 export default getQueryTypeComplexity;

--- a/src/analysis/typeComplexityAnalysis.ts
+++ b/src/analysis/typeComplexityAnalysis.ts
@@ -1,16 +1,10 @@
-import { query } from 'express';
 import { ASTNode, DocumentNode, Kind } from 'graphql';
 
 /**
- * This function should
- * 1. validate the query using graphql methods
- * 2. parse the query string using the graphql parse method
- * 3. itreate through the query AST and
- *      - cross reference the type weight object to check type weight
- *      - total all the eweights of all types in the query
- * 4. return the total as the query complexity
+ * Calculate the complexity for the query by recursivly traversing through the query AST,
+ * checking the query fields against the type weight object and totaling the weights of every field.
  *
- * TO DO: extend the functionality to work for mutations and subscriptions
+ * TO DO: extend the functionality to work for mutations and subscriptions and directives
  *
  * @param {string} queryAST
  * @param {any | undefined} varibales
@@ -22,75 +16,52 @@ function getQueryTypeComplexity(
     varibales: any | undefined,
     typeWeights: TypeWeightObject
 ): number {
-    const recursive = (node: ASTNode, parent: ASTNode | null = null): number => {
-        /** 
-         * pseudo code of the process
-         * 
-        // if 'kind' property is 'Document'
-            // iterate through queryAST.definitions array
-            // call recursive with object
-
-        // if 'kind' property is 'operationDefinition'
-            // check 'operation' value against the type weights and add to total
-            // call recursive with selectionSet property if it is not undefined
-
-        // if 'kind' is 'selectionSet'
-            // iterate shrough the 'selections' array of fields
-            // if 'selectinSet' is not undefined, call recursive with the field
-
-        // if 'kind' property is 'feild'
-            // check the fields name.value against the type weights and total
-            // if there is a match, it is an objcet type with feilds, 
-                // call recursive with selectionSet property if it is not undefined
-            // if it is not a match, it is a scalar field, look in the parent.name.value to check type weights feilds
-        */
-
+    const getComplexityOfNode = (node: ASTNode, parent: ASTNode = node): number => {
         let complexity = 0;
-        const parentName: string = parent?.operation || parent?.name.value || null;
 
         if (node.kind === Kind.DOCUMENT) {
             // if 'kind' property is a 'Document'
             // iterate through queryAST.definitions array
             for (let i = 0; i < node.definitions.length; i + 1) {
                 // call recursive with the definition node
-                complexity += recursive(node.definitions[i], node);
+                complexity += getComplexityOfNode(node.definitions[i], node);
             }
         } else if (node.kind === Kind.OPERATION_DEFINITION) {
             // if 'kind' property is 'operationDefinition'
             // TODO: case-sensitive
-            if (node.operation in typeWeights) {
+            if (node.operation.toLocaleLowerCase() in typeWeights) {
                 // check 'operation' value against the type weights and add to total
                 complexity += typeWeights[node.operation].weight;
                 // call recursive with selectionSet property if it is not undefined
-                if (node.selectionSet) complexity += recursive(node.selectionSet, node);
+                if (node.selectionSet) complexity += getComplexityOfNode(node.selectionSet, node);
             }
         } else if (node.kind === Kind.SELECTION_SET) {
             // if 'kind' is 'selectionSet'
             // iterate shrough the 'selections' array of fields
             for (let i = 0; i < node.selections.length; i + 1) {
                 // call recursive with the field
-                complexity += recursive(node.selections[i], parent); // passing the current parent through because selection sets act only as intermediaries
+                complexity += getComplexityOfNode(node.selections[i], parent); // passing the current parent through because selection sets act only as intermediaries
             }
         } else if (node.kind === Kind.FIELD) {
             // if 'kind' property is 'field'
             // check the fields name.value against the type weights and total
             // TODO: case-sensitive
-            if (node.name.value in typeWeights) {
+            if (node.name.value.toLocaleLowerCase() in typeWeights) {
                 // if there is a match, it is an objcet type with feilds,
                 complexity += typeWeights[node.name.value].weight;
                 // call recursive with selectionSet property if it is not undefined
-                if (node.selectionSet) complexity += recursive(node.selectionSet, node);
+                if (node.selectionSet) complexity += getComplexityOfNode(node.selectionSet, node);
                 // node.name.value in typeWeights[parent.operation || parent.name.value].fields
-            } else if (parent?.opeartion) {
-                // if it is not a match, it is a scalar field, look in the parent.name.value to check type weights feilds
-                // TODO: if it is a list, need to look at the parent
-                complexity += typeWeights[parent.name.value].fields[node.name.value];
+            } else {
+                // TODO: if it is not a match, it is a scalar field or list,
+                // if (parent?.objective !== null) {
+                // }
+                // const weight = typeWeights[parent.name.value].fields[node.name.value];
             }
         }
-
         return complexity;
     };
-    return recursive(queryAST);
+    return getComplexityOfNode(queryAST);
 }
 
 export default getQueryTypeComplexity;

--- a/src/analysis/typeComplexityAnalysis.ts
+++ b/src/analysis/typeComplexityAnalysis.ts
@@ -1,4 +1,5 @@
 import { DocumentNode } from 'graphql';
+import { TypeWeightObject } from '../@types/buildTypeWeights';
 import { documentNode } from './ASTnodefunctions';
 
 /**

--- a/src/analysis/typeComplexityAnalysis.ts
+++ b/src/analysis/typeComplexityAnalysis.ts
@@ -16,7 +16,6 @@ import {
  * @param {any | undefined} varibales
  * @param {TypeWeightObject} typeWeights
  */
-// TODO add queryVaribables parameter
 function getQueryTypeComplexity(
     queryAST: DocumentNode,
     variables: any | undefined,

--- a/src/analysis/typeComplexityAnalysis.ts
+++ b/src/analysis/typeComplexityAnalysis.ts
@@ -1,10 +1,5 @@
-import { ASTNode, DocumentNode, Kind } from 'graphql';
-import {
-    selectionSetNode,
-    fieldNode,
-    documentNode,
-    operationDefinitionNode,
-} from './ASTnodefunctions';
+import { DocumentNode } from 'graphql';
+import { documentNode } from './ASTnodefunctions';
 
 /**
  * Calculate the complexity for the query by recursivly traversing through the query AST,

--- a/src/analysis/typeComplexityAnalysis.ts
+++ b/src/analysis/typeComplexityAnalysis.ts
@@ -1,4 +1,10 @@
 import { ASTNode, DocumentNode, Kind } from 'graphql';
+import {
+    selectionSetNode,
+    fieldNode,
+    documentNode,
+    operationDefinitionNode,
+} from './ASTnodefunctions';
 
 /**
  * Calculate the complexity for the query by recursivly traversing through the query AST,
@@ -13,55 +19,12 @@ import { ASTNode, DocumentNode, Kind } from 'graphql';
 // TODO add queryVaribables parameter
 function getQueryTypeComplexity(
     queryAST: DocumentNode,
-    varibales: any | undefined,
+    variables: any | undefined,
     typeWeights: TypeWeightObject
 ): number {
-    const getComplexityOfNode = (node: ASTNode, parent: ASTNode = node): number => {
-        let complexity = 0;
-
-        if (node.kind === Kind.DOCUMENT) {
-            // if 'kind' property is a 'Document'
-            // iterate through queryAST.definitions array
-            for (let i = 0; i < node.definitions.length; i + 1) {
-                // call recursive with the definition node
-                complexity += getComplexityOfNode(node.definitions[i], node);
-            }
-        } else if (node.kind === Kind.OPERATION_DEFINITION) {
-            // if 'kind' property is 'operationDefinition'
-            // TODO: case-sensitive
-            if (node.operation.toLocaleLowerCase() in typeWeights) {
-                // check 'operation' value against the type weights and add to total
-                complexity += typeWeights[node.operation].weight;
-                // call recursive with selectionSet property if it is not undefined
-                if (node.selectionSet) complexity += getComplexityOfNode(node.selectionSet, node);
-            }
-        } else if (node.kind === Kind.SELECTION_SET) {
-            // if 'kind' is 'selectionSet'
-            // iterate shrough the 'selections' array of fields
-            for (let i = 0; i < node.selections.length; i + 1) {
-                // call recursive with the field
-                complexity += getComplexityOfNode(node.selections[i], parent); // passing the current parent through because selection sets act only as intermediaries
-            }
-        } else if (node.kind === Kind.FIELD) {
-            // if 'kind' property is 'field'
-            // check the fields name.value against the type weights and total
-            // TODO: case-sensitive
-            if (node.name.value.toLocaleLowerCase() in typeWeights) {
-                // if there is a match, it is an objcet type with feilds,
-                complexity += typeWeights[node.name.value].weight;
-                // call recursive with selectionSet property if it is not undefined
-                if (node.selectionSet) complexity += getComplexityOfNode(node.selectionSet, node);
-                // node.name.value in typeWeights[parent.operation || parent.name.value].fields
-            } else {
-                // TODO: if it is not a match, it is a scalar field or list,
-                // if (parent?.objective !== null) {
-                // }
-                // const weight = typeWeights[parent.name.value].fields[node.name.value];
-            }
-        }
-        return complexity;
-    };
-    return getComplexityOfNode(queryAST);
+    let complexity = 0;
+    complexity += documentNode(queryAST, typeWeights, variables);
+    return complexity;
 }
 
 export default getQueryTypeComplexity;

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -6,6 +6,8 @@ import { Request, Response, NextFunction, RequestHandler } from 'express';
 import buildTypeWeightsFromSchema, { defaultTypeWeightsConfig } from '../analysis/buildTypeWeights';
 import setupRateLimiter from './rateLimiterSetup';
 import getQueryTypeComplexity from '../analysis/typeComplexityAnalysis';
+import { RateLimiterOptions, RateLimiterSelection } from '../@types/rateLimit';
+import { TypeWeightConfig } from '../@types/buildTypeWeights';
 
 // FIXME: Will the developer be responsible for first parsing the schema from a file?
 // Can consider accepting a string representing a the filepath to a schema
@@ -50,7 +52,6 @@ export function expressRateLimiter(
             console.log('There is no query on the request');
             return next();
         }
-
         /**
          * There are numorous ways to get the ip address off of the request object.
          * - the header 'x-forward-for' will hold the originating ip address if a proxy is placed infront of the server. This would be commen for a production build.
@@ -68,10 +69,12 @@ export function expressRateLimiter(
         // validate the query against the schema. The GraphQL validation function returns an array of errors.
         const validationErrors = validate(schema, queryAST);
         // check if the length of the returned GraphQL Errors array is greater than zero. If it is, there were errors. Call next so that the GraphQL server can handle those.
-        if (validationErrors.length > 0) return next();
+        if (validationErrors.length > 0) {
+            // FIXME: Customize this error to throw the GraphQLError
+            return next(Error('invalid query'));
+        }
 
         const queryComplexity = getQueryTypeComplexity(queryAST, variables, typeWeightObject);
-
         try {
             // process the request and conditinoally respond to client with status code 429 o
             // r pass the request onto the next middleware function
@@ -83,14 +86,15 @@ export function expressRateLimiter(
             if (rateLimiterResponse.success === false) {
                 // TODO: add a header 'Retry-After' with the time to wait untill next query will succeed
                 // FIXME: send information about query complexity, tokens, etc, to the client on rejected query
-                res.status(429).send();
+                res.status(429).json({ graphqlGate: rateLimiterResponse });
+            } else {
+                res.locals.graphqlGate = {
+                    timestamp: requestTimestamp,
+                    complexity: queryComplexity,
+                    tokens: rateLimiterResponse.tokens,
+                };
+                return next();
             }
-            res.locals.graphqlGate = {
-                timestamp: requestTimestamp,
-                complexity: queryComplexity,
-                tokens: rateLimiterResponse.tokens,
-            };
-            return next();
         } catch (err) {
             return next(err);
         }

--- a/src/middleware/rateLimiterSetup.ts
+++ b/src/middleware/rateLimiterSetup.ts
@@ -1,4 +1,5 @@
 import Redis from 'ioredis';
+import { RateLimiterOptions, RateLimiterSelection } from '../@types/rateLimit';
 import TokenBucket from '../rateLimiters/tokenBucket';
 
 /**

--- a/src/rateLimiters/tokenBucket.ts
+++ b/src/rateLimiters/tokenBucket.ts
@@ -1,4 +1,5 @@
 import Redis from 'ioredis';
+import { RateLimiter, RateLimiterResponse, RedisBucket } from '../@types/rateLimit';
 
 /**
  * The TokenBucket instance of a RateLimiter limits requests based on a unique user ID.
@@ -98,7 +99,7 @@ class TokenBucket implements RateLimiter {
         timestamp: number
     ): number => {
         const timeSinceLastQueryInSeconds: number = Math.floor(
-            (timestamp - bucket.timestamp) / 1000 // 1000 ms in a second
+            (timestamp - bucket.timestamp) / 1000 // 1000 ms in a second FIXME: magic number if specifying custom timeframe
         );
         const tokensToAdd = timeSinceLastQueryInSeconds * this.refillRate;
         const updatedTokenCount = bucket.tokens + tokensToAdd;

--- a/test/analysis/typeComplexityAnalysis.test.ts
+++ b/test/analysis/typeComplexityAnalysis.test.ts
@@ -172,7 +172,7 @@ describe('Test getQueryTypeComplexity function', () => {
     let variables: any | undefined;
     describe('Calculates the correct type complexity for queries', () => {
         test('with one feild', () => {
-            query = `uery { scalars { num } }`;
+            query = `query { scalars { num } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(2); // Query 1 + Scalars 1
         });
 
@@ -181,22 +181,22 @@ describe('Test getQueryTypeComplexity function', () => {
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(3); // Query 1 + scalars 1 + test 1
         });
 
-        xtest('with one level of nested fields', () => {
+        test('with one level of nested fields', () => {
             query = `query { scalars { num, test { name } } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(3); // Query 1 + scalars 1 + test 1
         });
 
-        xtest('with multiple levels of nesting', () => {
+        test('with multiple levels of nesting', () => {
             query = `query { scalars { num, test { name, scalars { id } } } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(4); // Query 1 + scalars 1 + test 1 + scalars 1
         });
 
-        xtest('with aliases', () => {
-            query = `query { foo: scalar { num } bar: scalar { id }}`;
+        test('with aliases', () => {
+            query = `query { foo: scalars { num } bar: scalars { id }}`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(3); // Query 1 + scalar 1 + scalar 1
         });
 
-        xtest('with all scalar fields', () => {
+        test('with all scalar fields', () => {
             query = `query { scalars { id, num, float, bool, string } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(2); // Query 1 + scalar 1
         });
@@ -304,22 +304,6 @@ describe('Test getQueryTypeComplexity function', () => {
         });
 
         // todo: directives @skip, @include and custom directives
-
-        // todo: expand on error handling
-        xtest('Throws an error if for a bad query', () => {
-            query = `query { hello { hi } }`; // type doesn't exist
-            expect(() => getQueryTypeComplexity(parse(query), variables, typeWeights)).toThrow(
-                'Error'
-            );
-            query = `query { hero(episode: EMPIRE){ starship } }`; // field doesn't exist
-            expect(() => getQueryTypeComplexity(parse(query), variables, typeWeights)).toThrow(
-                'Error'
-            );
-            query = `query { hero(episode: EMPIRE) { id, name }`; // missing a closing bracket
-            expect(() => getQueryTypeComplexity(parse(query), variables, typeWeights)).toThrow(
-                'Error'
-            );
-        });
     });
 
     xdescribe('Calculates the correct type complexity for mutations', () => {});

--- a/test/analysis/typeComplexityAnalysis.test.ts
+++ b/test/analysis/typeComplexityAnalysis.test.ts
@@ -1,6 +1,7 @@
 import { ArgumentNode } from 'graphql/language';
 import { parse } from 'graphql';
 import getQueryTypeComplexity from '../../src/analysis/typeComplexityAnalysis';
+import { TypeWeightObject } from '../../src/@types/buildTypeWeights';
 
 /** 
  * Here is the schema that creates the followning 'typeWeightsObject' used for the tests

--- a/test/analysis/typeComplexityAnalysis.test.ts
+++ b/test/analysis/typeComplexityAnalysis.test.ts
@@ -172,49 +172,49 @@ describe('Test getQueryTypeComplexity function', () => {
     let variables: any | undefined;
     describe('Calculates the correct type complexity for queries', () => {
         test('with one feild', () => {
-            query = `query { scalars { num } }`;
+            query = `uery { scalars { num } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(2); // Query 1 + Scalars 1
         });
 
-        xtest('with two or more fields', () => {
-            query = `Query { scalars { num } test { name } }`;
+        test('with two or more fields', () => {
+            query = `query { scalars { num } test { name } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(3); // Query 1 + scalars 1 + test 1
         });
 
         xtest('with one level of nested fields', () => {
-            query = `Query { scalars { num, test { name } } }`;
+            query = `query { scalars { num, test { name } } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(3); // Query 1 + scalars 1 + test 1
         });
 
         xtest('with multiple levels of nesting', () => {
-            query = `Query { scalars { num, test { name, scalars { id } } } }`;
+            query = `query { scalars { num, test { name, scalars { id } } } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(4); // Query 1 + scalars 1 + test 1 + scalars 1
         });
 
         xtest('with aliases', () => {
-            query = `Query { foo: scalar { num } bar: scalar { id }}`;
+            query = `query { foo: scalar { num } bar: scalar { id }}`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(3); // Query 1 + scalar 1 + scalar 1
         });
 
         xtest('with all scalar fields', () => {
-            query = `Query { scalars { id, num, float, bool, string } }`;
+            query = `query { scalars { id, num, float, bool, string } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(2); // Query 1 + scalar 1
         });
 
         xtest('with arguments and variables', () => {
-            query = `Query { hero(episode: EMPIRE) { id, name } }`;
+            query = `query { hero(episode: EMPIRE) { id, name } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(2); // Query 1 + hero/character 1
-            query = `Query { human(id: 1) { id, name, appearsIn } }`;
+            query = `query { human(id: 1) { id, name, appearsIn } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(3); // Query 1 + human/character 1 + appearsIn/episode
             // argument passed in as a variable
             variables = { ep: 'EMPIRE' };
-            query = `Query varibaleQuery ($ep: Episode){ hero(episode: $ep) { id, name } }`;
+            query = `query varibaleQuery ($ep: Episode){ hero(episode: $ep) { id, name } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(2); // Query 1 + hero/character 1
         });
 
         xtest('with fragments', () => {
             query = `
-            Query {
+            query {
                 leftComparison: hero(episode: EMPIRE) {
                   ...comparisonFields
                 }
@@ -233,7 +233,7 @@ describe('Test getQueryTypeComplexity function', () => {
 
         xtest('with inline fragments', () => {
             query = `
-            Query {
+            query {
                 hero(episode: EMPIRE) {
                     name
                     ... on Droid {
@@ -252,7 +252,7 @@ describe('Test getQueryTypeComplexity function', () => {
          */
         xtest('with lists of unknown size', () => {
             query = `
-            Query { 
+            query { 
                 search(text: 'hi') { 
                     id
                     name
@@ -307,15 +307,15 @@ describe('Test getQueryTypeComplexity function', () => {
 
         // todo: expand on error handling
         xtest('Throws an error if for a bad query', () => {
-            query = `Query { hello { hi } }`; // type doesn't exist
+            query = `query { hello { hi } }`; // type doesn't exist
             expect(() => getQueryTypeComplexity(parse(query), variables, typeWeights)).toThrow(
                 'Error'
             );
-            query = `Query { hero(episode: EMPIRE){ starship } }`; // field doesn't exist
+            query = `query { hero(episode: EMPIRE){ starship } }`; // field doesn't exist
             expect(() => getQueryTypeComplexity(parse(query), variables, typeWeights)).toThrow(
                 'Error'
             );
-            query = `Query { hero(episode: EMPIRE) { id, name }`; // missing a closing bracket
+            query = `query { hero(episode: EMPIRE) { id, name }`; // missing a closing bracket
             expect(() => getQueryTypeComplexity(parse(query), variables, typeWeights)).toThrow(
                 'Error'
             );

--- a/test/analysis/typeComplexityAnalysis.test.ts
+++ b/test/analysis/typeComplexityAnalysis.test.ts
@@ -103,7 +103,7 @@ const typeWeights: TypeWeightObject = {
         fields: {
             // FIXME: update the function def that is supposed te be here to match implementation
             // FIXME: add the function definition for the 'search' field which returns a list
-            reviews: (arg, type) => arg * type.weight,
+            reviews: (arg) => 1,
         },
     },
     episode: {
@@ -172,36 +172,36 @@ describe('Test getQueryTypeComplexity function', () => {
     let variables: any | undefined;
     describe('Calculates the correct type complexity for queries', () => {
         test('with one feild', () => {
-            query = `Query { scalars { num } }`;
+            query = `query { scalars { num } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(2); // Query 1 + Scalars 1
         });
 
-        test('with two or more fields', () => {
+        xtest('with two or more fields', () => {
             query = `Query { scalars { num } test { name } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(3); // Query 1 + scalars 1 + test 1
         });
 
-        test('with one level of nested fields', () => {
+        xtest('with one level of nested fields', () => {
             query = `Query { scalars { num, test { name } } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(3); // Query 1 + scalars 1 + test 1
         });
 
-        test('with multiple levels of nesting', () => {
+        xtest('with multiple levels of nesting', () => {
             query = `Query { scalars { num, test { name, scalars { id } } } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(4); // Query 1 + scalars 1 + test 1 + scalars 1
         });
 
-        test('with aliases', () => {
+        xtest('with aliases', () => {
             query = `Query { foo: scalar { num } bar: scalar { id }}`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(3); // Query 1 + scalar 1 + scalar 1
         });
 
-        test('with all scalar fields', () => {
+        xtest('with all scalar fields', () => {
             query = `Query { scalars { id, num, float, bool, string } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(2); // Query 1 + scalar 1
         });
 
-        test('with arguments and variables', () => {
+        xtest('with arguments and variables', () => {
             query = `Query { hero(episode: EMPIRE) { id, name } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(2); // Query 1 + hero/character 1
             query = `Query { human(id: 1) { id, name, appearsIn } }`;
@@ -212,7 +212,7 @@ describe('Test getQueryTypeComplexity function', () => {
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(2); // Query 1 + hero/character 1
         });
 
-        test('with fragments', () => {
+        xtest('with fragments', () => {
             query = `
             Query {
                 leftComparison: hero(episode: EMPIRE) {
@@ -231,7 +231,7 @@ describe('Test getQueryTypeComplexity function', () => {
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(5); // Query 1 + 2*(character 1 + appearsIn/episode 1)
         });
 
-        test('with inline fragments', () => {
+        xtest('with inline fragments', () => {
             query = `
             Query {
                 hero(episode: EMPIRE) {
@@ -261,7 +261,7 @@ describe('Test getQueryTypeComplexity function', () => {
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(false); // ?
         });
 
-        test('with lists detrmined by arguments and variables', () => {
+        xtest('with lists detrmined by arguments and variables', () => {
             query = `Query {reviews(episode: EMPIRE, first: 3) { stars, commentary } }`;
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(4); // 1 Query + 3 reviews
             variables = { first: 3 };
@@ -269,7 +269,7 @@ describe('Test getQueryTypeComplexity function', () => {
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(4); // 1 Query + 3 reviews
         });
 
-        test('with nested lists', () => {
+        xtest('with nested lists', () => {
             query = `
             query { 
                 human(id: 1) { 
@@ -285,7 +285,7 @@ describe('Test getQueryTypeComplexity function', () => {
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(17); // 1 Query + 1 human/character +  (5 friends/character X 3 friends/characters)
         });
 
-        test('accounting for __typename feild', () => {
+        xtest('accounting for __typename feild', () => {
             query = `
             query {
                 search(text: "an", first: 4) {
@@ -306,7 +306,7 @@ describe('Test getQueryTypeComplexity function', () => {
         // todo: directives @skip, @include and custom directives
 
         // todo: expand on error handling
-        test('Throws an error if for a bad query', () => {
+        xtest('Throws an error if for a bad query', () => {
             query = `Query { hello { hi } }`; // type doesn't exist
             expect(() => getQueryTypeComplexity(parse(query), variables, typeWeights)).toThrow(
                 'Error'

--- a/test/analysis/typeComplexityAnalysis.test.ts
+++ b/test/analysis/typeComplexityAnalysis.test.ts
@@ -167,7 +167,7 @@ const typeWeights: TypeWeightObject = {
     },
 };
 
-xdescribe('Test getQueryTypeComplexity function', () => {
+describe('Test getQueryTypeComplexity function', () => {
     let query = '';
     let variables: any | undefined;
     describe('Calculates the correct type complexity for queries', () => {

--- a/test/rateLimiters/tokenBucket.test.ts
+++ b/test/rateLimiters/tokenBucket.test.ts
@@ -1,4 +1,5 @@
 import * as ioredis from 'ioredis';
+import { RedisBucket } from '../../src/@types/rateLimit';
 import TokenBucket from '../../src/rateLimiters/tokenBucket';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,9 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "noEmit": false,
-        "typeRoots": ["./@types", "node_modules/@types"],
-        "types": ["node", "jest"]
+        "typeRoots": ["src/@types", "node_modules/@types"],
+        "types": ["node", "jest"],
+        "outDir": "build/"
     },
     "include": ["src/**/*.ts", "src/**/*.js", "test/**/*.ts", "test/**/*.js"],
     "exclude": ["node_modules", "**/*.spec.ts"]


### PR DESCRIPTION
### Summary
This is a functioning type complexity analysis algorithm that passes tests up to and including `with aliases`. The algorithm traverses the query AST which is a bunch of nested nodes of different graphQL types. The algorithm implements a different function for each AST Node Type so that the algorithm is modular and easily extendable. To add new functionality, create a new function to handle the GraphQL Node that holds the responsibility for that functionality.

Still to do
* handle arguments and variables
* handle fragments
* handling lists

### Type of Change
- [ ] New feature (non-breaking change which adds functionality)

### Issues
* closes #2 

### Evidence
<img width="661" alt="Screen Shot 2022-06-02 at 9 29 12 AM" src="https://user-images.githubusercontent.com/89324687/171641485-88b9648a-8704-47bf-8247-0ae651bda42d.png">
