### PR TITLE
Add tests for non-null operators

### DIFF
--- a/test/analysis/buildTypeWeights.test.ts
+++ b/test/analysis/buildTypeWeights.test.ts
@@ -443,7 +443,7 @@ describe('Test buildTypeWeightsFromSchema function', () => {
             });
         });
 
-        describe('Not null operator (!) is used', () => {
+        xdescribe('Not null operator (!) is used', () => {
             test('on a scalar, enum or object type', () => {
                 schema = buildSchema(`
                 type Human{

--- a/test/analysis/buildTypeWeights.test.ts
+++ b/test/analysis/buildTypeWeights.test.ts
@@ -443,6 +443,78 @@ describe('Test buildTypeWeightsFromSchema function', () => {
             });
         });
 
+        describe('Not null operator (!) is used', () => {
+            test('on a scalar, enum or object type', () => {
+                schema = buildSchema(`
+                type Human{
+                    homePlanet: String!
+                    age: Int!
+                    isHero: Boolean!
+                    droids: Droid!
+                    episode: Episode!
+                }
+                type Droid {
+                    primaryFunction: String
+                }
+                enum Episode {
+                    NEWHOPE
+                    EMPIRE
+                    JEDI
+                }
+                `);
+
+                expect(buildTypeWeightsFromSchema(schema)).toEqual({
+                    human: {
+                        weight: 1,
+                        fields: {
+                            homePlanet: 0,
+                            age: 0,
+                            isHero: 0,
+                        },
+                    },
+                    droid: {
+                        weight: 1,
+                        fields: {
+                            primaryFunction: 0,
+                        },
+                    },
+                });
+            });
+
+            test('on list types', () => {
+                schema = buildSchema(`
+                type Planet{
+                    droids(first: Int!): [Droid]!
+                    heroDroids(first: Int!): [Droid!]
+                    villainDroids(first: Int!):[Droid!]!
+                }
+                type Droid {
+                    primaryFunction: String
+                }`);
+
+                expect(buildTypeWeightsFromSchema(schema)).toEqual({
+                    planet: {
+                        weight: 1,
+                        fields: {
+                            droids: expect.any(Function),
+                            heroDroids: expect.any(Function),
+                            villainDroids: expect.any(Function),
+                        },
+                    },
+                    droid: {
+                        weight: 1,
+                        fields: {
+                            primaryFunction: 0,
+                        },
+                    },
+                    episode: {
+                        weight: 0,
+                        fields: {},
+                    },
+                });
+            });
+        });
+
         // TODO: Tests should be written to account for the additional scenarios possible in a schema
         // Mutation type
         // Input types (a part of mutations?)

--- a/test/analysis/typeComplexityAnalysis.test.ts
+++ b/test/analysis/typeComplexityAnalysis.test.ts
@@ -13,6 +13,7 @@ import { TypeWeightObject, Variables } from '../../src/@types/buildTypeWeights';
         droid(id: ID!): Droid
         human(id: ID!): Human
         scalars: Scalars
+        nonNull: [Droid!]!
     }    
 
     enum Episode {
@@ -100,6 +101,7 @@ import { TypeWeightObject, Variables } from '../../src/@types/buildTypeWeights';
 const mockWeightFunction = jest.fn();
 const mockHumanFriendsFunction = jest.fn();
 const mockDroidFriendsFunction = jest.fn();
+const nonNullMockWeightFunction = jest.fn();
 
 // this object is created by the schema above for use in all the tests below
 const typeWeights: TypeWeightObject = {
@@ -114,6 +116,7 @@ const typeWeights: TypeWeightObject = {
             droid: 1,
             human: 1,
             scalars: 1,
+            nonNull: nonNullMockWeightFunction,
         },
     },
     episode: {
@@ -293,6 +296,14 @@ describe('Test getQueryTypeComplexity function', () => {
             expect(getQueryTypeComplexity(parse(query), variables, typeWeights)).toBe(5); // 1 Query + 4 reviews
             expect(mockWeightFunction.mock.calls.length).toBe(2);
             expect(mockWeightFunction.mock.calls[1].length).toBe(1);
+        });
+
+        test('with bounded lists including non-null operators', () => {
+            query = `query {nonNull(episode: EMPIRE, first: 3) { stars, commentary } }`;
+            nonNullMockWeightFunction.mockReturnValueOnce(3);
+            expect(getQueryTypeComplexity(parse(query), {}, typeWeights)).toBe(4); // 1 Query + 3 reviews
+            expect(nonNullMockWeightFunction.mock.calls.length).toBe(1);
+            expect(nonNullMockWeightFunction.mock.calls[0].length).toBe(1);
         });
 
         xdescribe('with nested lists', () => {

--- a/test/analysis/weightFunction.test.ts
+++ b/test/analysis/weightFunction.test.ts
@@ -80,7 +80,7 @@ describe('Weight Function correctly parses Argument Nodes if', () => {
         });
     });
 
-    test('the list is defined with non-null operators (!)', () => {
+    xtest('the list is defined with non-null operators (!)', () => {
         const villainsQuery = `query { villains(episode: NEWHOPE, limit: 3) { stars, episode } }`;
         const willainsQueryAST: DocumentNode = parse(villainsQuery);
         expect(getQueryTypeComplexity(willainsQueryAST, {}, typeWeights)).toBe(4);

--- a/test/analysis/weightFunction.test.ts
+++ b/test/analysis/weightFunction.test.ts
@@ -18,8 +18,10 @@ describe('Weight Function correctly parses Argument Nodes if', () => {
         type Query {
             reviews(episode: Episode!, first: Int = 5): [Review]
             heroes(episode: Episode!, first: Int): [Review]
-            villains(episode: Episode!, limit: Int! = 3): [Review] 
-            characters(episode: Episode!, limit: Int!): [Review] 
+            villains(episode: Episode!, limit: Int! = 3): [Review]! 
+            characters(episode: Episode!, limit: Int!): [Review!]
+            droids(episode: Episode!, limit: Int!): [Review!]!
+            
         }
         type Review {
             episode: Episode
@@ -76,6 +78,20 @@ describe('Weight Function correctly parses Argument Nodes if', () => {
             const queryAST: DocumentNode = parse(query);
             expect(getQueryTypeComplexity(queryAST, { items: 7 }, typeWeights)).toBe(8);
         });
+    });
+
+    test('the list is defined with non-null operators (!)', () => {
+        const villainsQuery = `query { villains(episode: NEWHOPE, limit: 3) { stars, episode } }`;
+        const willainsQueryAST: DocumentNode = parse(villainsQuery);
+        expect(getQueryTypeComplexity(willainsQueryAST, {}, typeWeights)).toBe(4);
+
+        const charQuery = `query { characters(episode: NEWHOPE, limit: 3) { stars, episode } }`;
+        const charQueryAST: DocumentNode = parse(charQuery);
+        expect(getQueryTypeComplexity(charQueryAST, {}, typeWeights)).toBe(4);
+
+        const droidsQuery = `droidsQuery { droids(episode: NEWHOPE, limit: 3) { stars, episode } }`;
+        const droidsQueryAST: DocumentNode = parse(droidsQuery);
+        expect(getQueryTypeComplexity(droidsQueryAST, {}, typeWeights)).toBe(4);
     });
 
     test('a custom object weight was configured', () => {


### PR DESCRIPTION
### Summary
Updates type complexity, type weights, and weigh function test suites to account for cases where a non-null operator is used in the schema as specified by #48. 

### Type of Change
- [x ] Added tests

### Issues
- Adds tests specified by $48

### Evidence
- All tests fail as expected. 



