### PR TITLE
Completed analysis of include and skip directives

### DIFF
--- a/src/analysis/QueryParser.ts
+++ b/src/analysis/QueryParser.ts
@@ -23,9 +23,9 @@ import { FieldWeight, TypeWeightObject, Variables } from '../@types/buildTypeWei
  *  |               /
  *  |          Selection Node
  *  |  (Field,    Inline fragment, directives and fragment spread)
- *  |      |            |              \               \
- *  |  Field Node       |               \               \
- *  |      |            |       directiveCheck      fragmentCache
+ *  |      |            |              \                  \
+ *  |  Field Node       |               \                  \
+ *  |      |            |    directiveExcludeField        fragmentCache
  *  |<--calculateCast   |
  *  |                   |
  *  |<------------------|
@@ -187,7 +187,7 @@ class QueryParser {
         let complexity = 0;
         /**
          * process this node only if:
-         * 1. there is no directive
+         * 1. there is no include or skip directive
          * 2. there is a directive named inlcude and the value is true
          * 3. there is a directive named skip and the value is false
          */

--- a/src/analysis/QueryParser.ts
+++ b/src/analysis/QueryParser.ts
@@ -22,10 +22,10 @@ import { FieldWeight, TypeWeightObject, Variables } from '../@types/buildTypeWei
  *  |-----> Selection Set Node  <-------|
  *  |               /
  *  |          Selection Node
- *  |  (Field,    Inline fragment and fragment spread)
- *  |      |            |                    \
- *  |  Field Node       |                 fragmentCache
- *  |       |           |
+ *  |  (Field,    Inline fragment, directives and fragment spread)
+ *  |      |            |              \               \
+ *  |  Field Node       |               \               \
+ *  |      |            |       directiveCheck      fragmentCache
  *  |<--calculateCast   |
  *  |                   |
  *  |<------------------|

--- a/test/analysis/typeComplexityAnalysis.test.ts
+++ b/test/analysis/typeComplexityAnalysis.test.ts
@@ -935,7 +935,11 @@ describe('Test getQueryTypeComplexity function', () => {
             test('@include on object types', () => {
                 query = `query { 
                     hero(episode: EMPIRE) { 
-                        id, name 
+                        id, 
+                        name
+                        friends(first: 3) {
+                            name
+                        } 
                     } 
                     human(id: 1) @include(if: true) { 
                         id, 
@@ -943,12 +947,17 @@ describe('Test getQueryTypeComplexity function', () => {
                         homePlanet 
                     } 
                 }`;
-                // 1 query + 1 hero + 1 human
-                expect(queryParser.processQuery(parse(query))).toBe(3);
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 3 friends + 1 human
+                expect(queryParser.processQuery(parse(query))).toBe(6);
 
                 query = `query { 
                     hero(episode: EMPIRE) { 
-                        id, name 
+                        id, 
+                        name
+                        friends(first: 3) {
+                            name
+                        }  
                     } 
                     human(id: 1) @include(if: false) { 
                         id, 
@@ -956,14 +965,19 @@ describe('Test getQueryTypeComplexity function', () => {
                         homePlanet 
                     } 
                 }`;
-                // 1 query + 1 hero
-                expect(queryParser.processQuery(parse(query))).toBe(2);
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 3 friends
+                expect(queryParser.processQuery(parse(query))).toBe(5);
             });
 
             test('@skip on object types', () => {
                 query = `query { 
                     hero(episode: EMPIRE) { 
-                        id, name 
+                        id, 
+                        name
+                        friends(first: 3) {
+                            name
+                        } 
                     } 
                     human(id: 1) @skip(if: true) { 
                         id, 
@@ -971,12 +985,17 @@ describe('Test getQueryTypeComplexity function', () => {
                         homePlanet 
                     } 
                 }`;
-                // 1 query + 1 hero
-                expect(queryParser.processQuery(parse(query))).toBe(2);
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 3 friends
+                expect(queryParser.processQuery(parse(query))).toBe(5);
 
                 query = `query { 
                     hero(episode: EMPIRE) { 
-                        id, name 
+                        id, 
+                        name
+                        friends(first: 3) {
+                            name
+                        }  
                     } 
                     human(id: 1) @skip(if: false) { 
                         id, 
@@ -984,8 +1003,9 @@ describe('Test getQueryTypeComplexity function', () => {
                         homePlanet 
                     } 
                 }`;
-                // 1 query + 1 hero + 1 human
-                expect(queryParser.processQuery(parse(query))).toBe(3);
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 3 friends + 1 human
+                expect(queryParser.processQuery(parse(query))).toBe(6);
             });
 
             test('@skip with arguments and varibales', () => {
@@ -993,7 +1013,11 @@ describe('Test getQueryTypeComplexity function', () => {
                 queryParser = new QueryParser(typeWeights, variables);
                 query = `query ($directive: Boolean!){ 
                     hero(episode: EMPIRE) { 
-                        id, name 
+                        id, 
+                        name
+                        friends(first: 3) {
+                            name
+                        } 
                     } 
                     human(id: 1) @skip(if: $directive) { 
                         id, 
@@ -1001,13 +1025,18 @@ describe('Test getQueryTypeComplexity function', () => {
                         homePlanet 
                     } 
                 }`;
-                // 1 query + 1 hero + 1 human
-                expect(queryParser.processQuery(parse(query))).toBe(3);
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 3 friends + 1 human
+                expect(queryParser.processQuery(parse(query))).toBe(6);
                 variables = { directive: true };
                 queryParser = new QueryParser(typeWeights, variables);
                 query = `query ($directive: Boolean!){ 
                     hero(episode: EMPIRE) { 
-                        id, name 
+                        id, 
+                        name
+                        friends(first: 3) {
+                            name
+                        } 
                     } 
                     human(id: 1) @skip(if: $directive) { 
                         id, 
@@ -1015,8 +1044,9 @@ describe('Test getQueryTypeComplexity function', () => {
                         homePlanet 
                     } 
                 }`;
-                // 1 query + 1 hero
-                expect(queryParser.processQuery(parse(query))).toBe(2);
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 3 friends
+                expect(queryParser.processQuery(parse(query))).toBe(5);
             });
 
             test('@include with arguments and varibales', () => {
@@ -1024,7 +1054,11 @@ describe('Test getQueryTypeComplexity function', () => {
                 queryParser = new QueryParser(typeWeights, variables);
                 query = `query ($directive: Boolean!){ 
                     hero(episode: EMPIRE) { 
-                        id, name 
+                        id, 
+                        name
+                        friends(first: 3) {
+                            name
+                        } 
                     } 
                     human(id: 1) @include(if: $directive) { 
                         id, 
@@ -1032,13 +1066,18 @@ describe('Test getQueryTypeComplexity function', () => {
                         homePlanet 
                     } 
                 }`;
-                // 1 query + 1 hero
-                expect(queryParser.processQuery(parse(query))).toBe(2);
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 3 friends
+                expect(queryParser.processQuery(parse(query))).toBe(5);
                 variables = { directive: true };
                 queryParser = new QueryParser(typeWeights, variables);
                 query = `query ($directive: Boolean!){ 
                     hero(episode: EMPIRE) { 
-                        id, name 
+                        id, 
+                        name
+                        friends(first: 3) {
+                            name
+                        }  
                     } 
                     human(id: 1) @include(if: $directive) { 
                         id, 
@@ -1046,14 +1085,19 @@ describe('Test getQueryTypeComplexity function', () => {
                         homePlanet 
                     } 
                 }`;
-                // 1 query + 1 hero + 1 human
-                expect(queryParser.processQuery(parse(query))).toBe(3);
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 3 friends + 1 human
+                expect(queryParser.processQuery(parse(query))).toBe(6);
             });
 
             test('and other directives or arguments are ignored', () => {
                 query = `query { 
                     hero(episode: EMPIRE) { 
-                        id, name 
+                        id, 
+                        name
+                        friends(first: 3) {
+                            name
+                        } 
                     } 
                     human(id: 1) @ignore(if: true) { 
                         id, 
@@ -1061,11 +1105,16 @@ describe('Test getQueryTypeComplexity function', () => {
                         homePlanet 
                     } 
                 }`;
-                // 1 query + 1 hero + 1 human
-                expect(queryParser.processQuery(parse(query))).toBe(3);
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 3friends + 1 human
+                expect(queryParser.processQuery(parse(query))).toBe(6);
                 query = `query { 
                     hero(episode: EMPIRE) { 
-                        id, name 
+                        id, 
+                        name
+                        friends(first: 3) {
+                            name
+                        } 
                     } 
                     human(id: 1) @include(when: false) { 
                         id, 
@@ -1073,11 +1122,12 @@ describe('Test getQueryTypeComplexity function', () => {
                         homePlanet 
                     } 
                 }`;
-                // 1 query + 1 hero
-                expect(queryParser.processQuery(parse(query))).toBe(2);
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 3 friends + 1 hero 1 human
+                expect(queryParser.processQuery(parse(query))).toBe(6);
             });
 
-            test('@include with other diretcives', () => {
+            test('@include with other directives', () => {
                 query = `query { 
                     hero(episode: EMPIRE) { 
                         id, 
@@ -1093,7 +1143,7 @@ describe('Test getQueryTypeComplexity function', () => {
                     } 
                 }`;
                 mockCharacterFriendsFunction.mockReturnValueOnce(3);
-                // 1 query + 1 hero + 1 human
+                // 1 query + 1 hero + 3 friends
                 expect(queryParser.processQuery(parse(query))).toBe(5);
                 query = `query { 
                     hero(episode: EMPIRE) { 
@@ -1110,7 +1160,7 @@ describe('Test getQueryTypeComplexity function', () => {
                     } 
                 }`;
                 mockCharacterFriendsFunction.mockReturnValueOnce(3);
-                // 1 query + 1 hero
+                // 1 query + 1 hero + 3 friends + 1 human
                 expect(queryParser.processQuery(parse(query))).toBe(6);
             });
         });

--- a/test/analysis/typeComplexityAnalysis.test.ts
+++ b/test/analysis/typeComplexityAnalysis.test.ts
@@ -1163,6 +1163,43 @@ describe('Test getQueryTypeComplexity function', () => {
                 // 1 query + 1 hero + 3 friends + 1 human
                 expect(queryParser.processQuery(parse(query))).toBe(6);
             });
+
+            test('@skip with other directives', () => {
+                query = `query { 
+                    hero(episode: EMPIRE) { 
+                        id, 
+                        name 
+                        friends(first: 3) {
+                            name
+                        }
+                    } 
+                    human(id: 1) @ignore(if: true) @skip(if: false) { 
+                        id, 
+                        name, 
+                        homePlanet 
+                    } 
+                }`;
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 3 friends
+                expect(queryParser.processQuery(parse(query))).toBe(6);
+                query = `query { 
+                    hero(episode: EMPIRE) { 
+                        id, 
+                        name 
+                        friends(first: 3) {
+                            name
+                        }
+                    } 
+                    human(id: 1) @ignore(if: true) @skip(if: true) { 
+                        id, 
+                        name, 
+                        homePlanet 
+                    } 
+                }`;
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 3 friends + 1 human
+                expect(queryParser.processQuery(parse(query))).toBe(5);
+            });
         });
 
         describe('with nested lists', () => {

--- a/test/analysis/typeComplexityAnalysis.test.ts
+++ b/test/analysis/typeComplexityAnalysis.test.ts
@@ -856,7 +856,7 @@ describe('Test getQueryTypeComplexity function', () => {
 
         // TODO: refine complexity analysis to consider directives includes and skip
         describe('with directives @includes and @skip', () => {
-            test('@includes on interfaces', () => {
+            test('@include on interfaces', () => {
                 query = `
                     query {
                         hero(episode: EMPIRE) {
@@ -932,7 +932,7 @@ describe('Test getQueryTypeComplexity function', () => {
                 expect(queryParser.processQuery(parse(query))).toBe(5);
             });
 
-            test('@includes on object types', () => {
+            test('@include on object types', () => {
                 query = `query { 
                     hero(episode: EMPIRE) { 
                         id, name 
@@ -1019,7 +1019,7 @@ describe('Test getQueryTypeComplexity function', () => {
                 expect(queryParser.processQuery(parse(query))).toBe(2);
             });
 
-            test('@includes with arguments and varibales', () => {
+            test('@include with arguments and varibales', () => {
                 variables = { directive: false };
                 queryParser = new QueryParser(typeWeights, variables);
                 query = `query ($directive: Boolean!){ 
@@ -1067,14 +1067,51 @@ describe('Test getQueryTypeComplexity function', () => {
                     hero(episode: EMPIRE) { 
                         id, name 
                     } 
-                    human(id: 1) @includes(when: false) { 
+                    human(id: 1) @include(when: false) { 
                         id, 
                         name, 
                         homePlanet 
                     } 
                 }`;
                 // 1 query + 1 hero
-                expect(queryParser.processQuery(parse(query))).toBe(3);
+                expect(queryParser.processQuery(parse(query))).toBe(2);
+            });
+
+            test('@include with other diretcives', () => {
+                query = `query { 
+                    hero(episode: EMPIRE) { 
+                        id, 
+                        name 
+                        friends(first: 3) {
+                            name
+                        }
+                    } 
+                    human(id: 1) @ignore(if: true) @include(if: false) { 
+                        id, 
+                        name, 
+                        homePlanet 
+                    } 
+                }`;
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero + 1 human
+                expect(queryParser.processQuery(parse(query))).toBe(5);
+                query = `query { 
+                    hero(episode: EMPIRE) { 
+                        id, 
+                        name 
+                        friends(first: 3) {
+                            name
+                        }
+                    } 
+                    human(id: 1) @ignore(if: true) @include(if: true) { 
+                        id, 
+                        name, 
+                        homePlanet 
+                    } 
+                }`;
+                mockCharacterFriendsFunction.mockReturnValueOnce(3);
+                // 1 query + 1 hero
+                expect(queryParser.processQuery(parse(query))).toBe(6);
             });
         });
 


### PR DESCRIPTION
### Summary
1. adds support for `@skip` and `@include` directives for more accurate cost analysis for queries using these directives
2. adds tests for these directives on objects, interfaces/fragments

### Type of Change
- [x] New feature (non-breaking change which adds functionality)

### Issues
closes #95 

### Evidence
![Screen Shot 2022-08-18 at 2 01 59 PM](https://user-images.githubusercontent.com/89324687/185494702-814a1de8-e1ea-46d6-a88c-6e118a3a56e8.png)
![Screen Shot 2022-08-18 at 2 05 54 PM](https://user-images.githubusercontent.com/89324687/185494790-b03d157e-8180-48db-b937-6b5defd3633c.png)

